### PR TITLE
Add custom serializers and deserializers for individual properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ protected array $otherExamples;
 // ^ items in the array will not be converted
 ```
 
+#### Serializer and Deserializer
+A custom Serializer and Deserializer can be specified for a property.
+This can be useful if you want to serialize a specific property in a different way.
+
+```php
+#[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
+protected TestClass $example;
+```
+
+Note that the custom Deserializer is responsible for returning the correct type.
+If an incompatible type is returned, an IncorrectTypeException is thrown.
+
 ### Exceptions
 The following exceptions may be thrown during serialization or deserialization:
 - [MissingPropertyException](#missingpropertyexception)

--- a/src/ArraySerializer.php
+++ b/src/ArraySerializer.php
@@ -25,7 +25,7 @@ use ReflectionClass;
  * @see Serialize
  * @see JsonSerializer
  */
-class ArraySerializer
+class ArraySerializer implements SerializerInterface
 {
     /**
      * Create a serializer from an object
@@ -67,7 +67,9 @@ class ArraySerializer
             $name = $attribute->getName() ?? $property->getName();
             $value = $property->getValue($item);
 
-            if ($value instanceof JsonSerializable) {
+            if ($customSerializer = $attribute->getSerializer()) {
+                $value = $customSerializer->serialize($value);
+            } else if ($value instanceof JsonSerializable) {
                 $value = $value->jsonSerialize();
             } elseif (is_object($value)) {
                 $value = $this->serialize($value);

--- a/src/DeserializerInterface.php
+++ b/src/DeserializerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Aternos\Serializer;
+
+use Aternos\Serializer\Exceptions\IncorrectTypeException;
+use Aternos\Serializer\Exceptions\MissingPropertyException;
+use Aternos\Serializer\Exceptions\UnsupportedTypeException;
+
+/**
+ * @template T
+ */
+interface DeserializerInterface
+{
+    /**
+     * Create a deserializer for a class
+     *
+     * @param class-string<T> $class the class to deserialize into
+     */
+    public function __construct(string $class);
+
+    /**
+     * Deserialize the data into an object
+     *
+     * @return T
+     * @throws IncorrectTypeException if the type of the property is incorrect
+     * @throws MissingPropertyException if a required property is missing
+     * @throws UnsupportedTypeException if the type of the property is unsupported
+     */
+    public function deserialize(mixed $data, string $path = ""): object;
+}

--- a/src/Json/JsonDeserializer.php
+++ b/src/Json/JsonDeserializer.php
@@ -3,9 +3,11 @@
 namespace Aternos\Serializer\Json;
 
 use Aternos\Serializer\ArrayDeserializer;
+use Aternos\Serializer\DeserializerInterface;
 use Aternos\Serializer\Exceptions\IncorrectTypeException;
 use Aternos\Serializer\Exceptions\MissingPropertyException;
 use Aternos\Serializer\Exceptions\UnsupportedTypeException;
+use InvalidArgumentException;
 use JsonException;
 
 /**
@@ -20,7 +22,7 @@ use JsonException;
  * @see Serialize
  * @template T
  */
-class JsonDeserializer
+class JsonDeserializer implements DeserializerInterface
 {
     protected ArrayDeserializer $arrayDeserializer;
 
@@ -45,13 +47,17 @@ class JsonDeserializer
      * @throws UnsupportedTypeException if the type of the property is unsupported
      * @throws JsonException if the data is invalid json
      */
-    public function deserialize(array|string $data, string $path = ""): object
+    public function deserialize(mixed $data, string $path = ""): object
     {
         if (is_string($data)) {
             $data = json_decode($data, true, flags: JSON_THROW_ON_ERROR);
             if (!is_array($data)) {
                 throw new IncorrectTypeException(".", $this->class, $data);
             }
+        }
+
+        if (!is_array($data)) {
+            throw new InvalidArgumentException("Data must be a string or an array.");
         }
 
         return $this->arrayDeserializer->deserialize($data, $path);

--- a/src/Json/JsonSerializer.php
+++ b/src/Json/JsonSerializer.php
@@ -5,6 +5,7 @@ namespace Aternos\Serializer\Json;
 use Aternos\Serializer\ArraySerializer;
 use Aternos\Serializer\Exceptions\IncorrectTypeException;
 use Aternos\Serializer\Exceptions\MissingPropertyException;
+use Aternos\Serializer\SerializerInterface;
 
 /**
  * A class that serializes objects using the Serialize attribute.
@@ -18,7 +19,7 @@ use Aternos\Serializer\Exceptions\MissingPropertyException;
  * @see ArraySerializer
  * @see PropertyJsonSerializer
  */
-class JsonSerializer
+class JsonSerializer implements SerializerInterface
 {
     protected ArraySerializer $arraySerializer;
 

--- a/src/Serialize.php
+++ b/src/Serialize.php
@@ -26,12 +26,16 @@ class Serialize
      * @param bool|null $required Whether the field is required
      * @param bool|null $allowNull Whether the field can be null
      * @param class-string|null $itemType The type of the items in the array
+     * @param SerializerInterface|null $serializer A custom serializer for this field
+     * @param DeserializerInterface|null $deserializer A custom deserializer for this field
      */
     public function __construct(
         protected ?string $name = null,
         protected ?bool   $required = null,
         protected ?bool   $allowNull = null,
         protected ?string $itemType = null,
+        protected ?SerializerInterface $serializer = null,
+        protected ?DeserializerInterface $deserializer = null,
     )
     {
     }
@@ -57,5 +61,21 @@ class Serialize
     public function getItemType(): ?string
     {
         return $this->itemType;
+    }
+
+    /**
+     * @return SerializerInterface|null
+     */
+    public function getSerializer(): ?SerializerInterface
+    {
+        return $this->serializer;
+    }
+
+    /**
+     * @return DeserializerInterface|null
+     */
+    public function getDeserializer(): ?DeserializerInterface
+    {
+        return $this->deserializer;
     }
 }

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aternos\Serializer;
+
+interface SerializerInterface
+{
+    /**
+     * Serialize an object into a scalar value or an array.
+     *
+     * @param object $item
+     * @return int|float|string|array|null
+     */
+    public function serialize(object $item): int|float|string|array|null;
+}

--- a/tests/src/Base64Deserializer.php
+++ b/tests/src/Base64Deserializer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aternos\Serializer\Test\Src;
+
+use Aternos\Serializer\DeserializerInterface;
+
+class Base64Deserializer implements DeserializerInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(protected string $class)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deserialize(mixed $data, string $path = ""): object
+    {
+        return unserialize(base64_decode($data));
+    }
+}

--- a/tests/src/Base64Serializer.php
+++ b/tests/src/Base64Serializer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aternos\Serializer\Test\Src;
+
+use Aternos\Serializer\SerializerInterface;
+
+class Base64Serializer implements SerializerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function serialize(object $item): int|float|string|array|null
+    {
+        return base64_encode(serialize($item));
+    }
+}

--- a/tests/src/CustomSerializerInvalidTypeTestClass.php
+++ b/tests/src/CustomSerializerInvalidTypeTestClass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aternos\Serializer\Test\Src;
+
+use Aternos\Serializer\Json\PropertyJsonSerializer;
+use Aternos\Serializer\Serialize;
+use JsonSerializable;
+
+class CustomSerializerInvalidTypeTestClass implements JsonSerializable
+{
+    use PropertyJsonSerializer;
+
+    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(SecondTestClass::class))]
+    protected TestClass $testClass;
+
+    public function __construct()
+    {
+        $this->testClass = new TestClass();
+    }
+
+    /**
+     * @return TestClass
+     */
+    public function getTestClass(): TestClass
+    {
+        return $this->testClass;
+    }
+}

--- a/tests/src/CustomSerializerTestClass.php
+++ b/tests/src/CustomSerializerTestClass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aternos\Serializer\Test\Src;
+
+use Aternos\Serializer\Json\PropertyJsonSerializer;
+use Aternos\Serializer\Serialize;
+use JsonSerializable;
+
+class CustomSerializerTestClass implements JsonSerializable
+{
+    use PropertyJsonSerializer;
+
+    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
+    protected TestClass $testClass;
+
+    public function __construct()
+    {
+        $this->testClass = new TestClass();
+    }
+
+    /**
+     * @return TestClass
+     */
+    public function getTestClass(): TestClass
+    {
+        return $this->testClass;
+    }
+}

--- a/tests/tests/Json/JsonDeserializerTest.php
+++ b/tests/tests/Json/JsonDeserializerTest.php
@@ -34,4 +34,12 @@ class JsonDeserializerTest extends TestCase
         $this->expectExceptionMessage("Expected '.' to be 'Aternos\Serializer\Test\Src\TestClass' found: 0");
         $deserializer->deserialize("0");
     }
+
+    public function testJsonDeserializerDataIsNotStringOrArray(): void
+    {
+        $deserializer = new JsonDeserializer(TestClass::class);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Data must be a string or an array.");
+        $deserializer->deserialize(0);
+    }
 }

--- a/tests/tests/SerializeTest.php
+++ b/tests/tests/SerializeTest.php
@@ -3,6 +3,8 @@
 namespace Aternos\Serializer\Test\Tests;
 
 use Aternos\Serializer\Serialize;
+use Aternos\Serializer\Test\Src\Base64Deserializer;
+use Aternos\Serializer\Test\Src\Base64Serializer;
 use Aternos\Serializer\Test\Src\TestClass;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +20,9 @@ class SerializeTest extends TestCase
     protected string $otherName = "other-name";
 
     protected string $nonSerializedName = "this isn't serialized";
+
+    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
+    protected TestClass $testClass;
 
     public function testConstruct(): void
     {
@@ -72,5 +77,14 @@ class SerializeTest extends TestCase
     {
         $property = new Serialize(itemType: TestClass::class);
         $this->assertSame(TestClass::class, $property->getItemType());
+    }
+
+    public function testGetCustomSerializerAndDeserializer(): void
+    {
+        $property = new ReflectionProperty($this, "testClass");
+        $attribute = Serialize::getAttribute($property);
+        $this->assertNotNull($attribute);
+        $this->assertInstanceOf(Base64Serializer::class, $attribute->getSerializer());
+        $this->assertInstanceOf(Base64Deserializer::class, $attribute->getDeserializer());
     }
 }

--- a/tests/tests/SerializerTest.php
+++ b/tests/tests/SerializerTest.php
@@ -8,6 +8,7 @@ use Aternos\Serializer\Exceptions\MissingPropertyException;
 use Aternos\Serializer\Json\PropertyJsonSerializer;
 use Aternos\Serializer\Serialize;
 use Aternos\Serializer\Test\Src\BuiltInTypeTestClass;
+use Aternos\Serializer\Test\Src\CustomSerializerTestClass;
 use Aternos\Serializer\Test\Src\DefaultValueTestClass;
 use Aternos\Serializer\Test\Src\SecondTestClass;
 use Aternos\Serializer\Test\Src\SerializerTestClass;
@@ -122,5 +123,12 @@ class SerializerTest extends TestCase
             "false" => null,
             "true" => null,
         ], $serializer->serialize($testClass));
+    }
+
+    public function testCustomSerializer(): void
+    {
+        $testClass = new CustomSerializerTestClass();
+        $expected = '{"testClass":"TzozNzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFRlc3RDbGFzcyI6OTp7czo2OiIAKgBhZ2UiO2k6MDtzOjE1OiIAKgBvcmlnaW5hbE5hbWUiO047czoxMToiACoAbnVsbGFibGUiO047czoxMjoiACoAYm9vbE9ySW50IjtiOjA7czoxNjoiACoAbm90QUpzb25GaWVsZCI7czo0OiJ0ZXN0IjtzOjE4OiIAKgBzZWNvbmRUZXN0Q2xhc3MiO047czo4OiIAKgBtaXhlZCI7TjtzOjg6IgAqAGZsb2F0IjtOO3M6ODoiACoAYXJyYXkiO047fQ=="}';
+        $this->assertEquals($expected, json_encode($testClass));
     }
 }


### PR DESCRIPTION
A custom Serializer and Deserializer can be specified for a property.
This can be useful if you want to serialize a specific property differently.

```php
#[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
protected TestClass $example;
```
