### PR TITLE
Add custom serializers and deserializers for array items

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ protected TestClass $example;
 Note that the custom Deserializer is responsible for returning the correct type.
 If an incompatible type is returned, an IncorrectTypeException is thrown.
 
+#### Item Serializer and Item Deserializer
+
+Custom Serializers and Deserializers can also be specified for array items.
+
+```php
+#[Serialize(itemSerializer: new Base64Serializer(), itemDeserializer: new Base64Deserializer(TestClass::class))]
+protected array $example = [];
+```
+
 ### Exceptions
 The following exceptions may be thrown during serialization or deserialization:
 - [MissingPropertyException](#missingpropertyexception)

--- a/src/ArrayDeserializer.php
+++ b/src/ArrayDeserializer.php
@@ -154,8 +154,8 @@ class ArrayDeserializer implements DeserializerInterface
             );
         }
 
-        if (is_array($value) && $attribute->getItemType() !== null) {
-            $deserializer = new static($attribute->getItemType());
+        if (is_array($value) && ($attribute->getItemType() !== null || $attribute->getItemDeserializer() !== null)) {
+            $deserializer = $attribute->getItemDeserializer() ?? new static($attribute->getItemType());
             $value = array_map(fn($item) => $deserializer->deserialize($item, $path . "." . $name), $value);
         }
 

--- a/src/ArraySerializer.php
+++ b/src/ArraySerializer.php
@@ -71,8 +71,15 @@ class ArraySerializer implements SerializerInterface
                 $value = $customSerializer->serialize($value);
             } else if ($value instanceof JsonSerializable) {
                 $value = $value->jsonSerialize();
-            } elseif (is_object($value)) {
+            } else if (is_object($value)) {
                 $value = $this->serialize($value);
+            } else if (is_array($value) && $customSerializer = $attribute->getItemSerializer()) {
+                foreach ($value as $key => $item) {
+                    if (!is_object($item)) {
+                        throw new IncorrectTypeException($property->getName(), "object", $item);
+                    }
+                    $value[$key] = $customSerializer->serialize($item);
+                }
             }
 
             $serializedProperties[$name] = $value;

--- a/src/Serialize.php
+++ b/src/Serialize.php
@@ -36,6 +36,8 @@ class Serialize
         protected ?string $itemType = null,
         protected ?SerializerInterface $serializer = null,
         protected ?DeserializerInterface $deserializer = null,
+        protected ?SerializerInterface $itemSerializer = null,
+        protected ?DeserializerInterface $itemDeserializer = null,
     )
     {
     }
@@ -77,5 +79,21 @@ class Serialize
     public function getDeserializer(): ?DeserializerInterface
     {
         return $this->deserializer;
+    }
+
+    /**
+     * @return SerializerInterface|null
+     */
+    public function getItemSerializer(): ?SerializerInterface
+    {
+        return $this->itemSerializer;
+    }
+
+    /**
+     * @return DeserializerInterface|null
+     */
+    public function getItemDeserializer(): ?DeserializerInterface
+    {
+        return $this->itemDeserializer;
     }
 }

--- a/tests/src/CustomSerializerInvalidTypeTestClass.php
+++ b/tests/src/CustomSerializerInvalidTypeTestClass.php
@@ -13,16 +13,11 @@ class CustomSerializerInvalidTypeTestClass implements JsonSerializable
     #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(SecondTestClass::class))]
     protected TestClass $testClass;
 
+    #[Serialize(itemSerializer: new Base64Serializer(), itemDeserializer: new Base64Deserializer(SecondTestClass::class))]
+    protected array $testArray = [];
+
     public function __construct()
     {
         $this->testClass = new TestClass();
-    }
-
-    /**
-     * @return TestClass
-     */
-    public function getTestClass(): TestClass
-    {
-        return $this->testClass;
     }
 }

--- a/tests/src/CustomSerializerTestClass.php
+++ b/tests/src/CustomSerializerTestClass.php
@@ -10,19 +10,40 @@ class CustomSerializerTestClass implements JsonSerializable
 {
     use PropertyJsonSerializer;
 
-    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
-    protected TestClass $testClass;
+    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(SecondTestClass::class))]
+    protected SecondTestClass $testClass;
+
+    #[Serialize(itemSerializer: new Base64Serializer(), itemDeserializer: new Base64Deserializer(SecondTestClass::class))]
+    protected array $testArray = [];
 
     public function __construct()
     {
-        $this->testClass = new TestClass();
+        $this->testClass = new SecondTestClass();
+        $this->testArray = [new SecondTestClass(), new SecondTestClass()];
     }
 
     /**
-     * @return TestClass
+     * @return SecondTestClass
      */
-    public function getTestClass(): TestClass
+    public function getTestClass(): SecondTestClass
     {
         return $this->testClass;
+    }
+
+    /**
+     * @return SecondTestClass[]
+     */
+    public function getTestArray(): array
+    {
+        return $this->testArray;
+    }
+
+    /**
+     * @param array $testArray
+     * @return void
+     */
+    public function setTestArray(array $testArray): void
+    {
+        $this->testArray = $testArray;
     }
 }

--- a/tests/tests/DeserializerTest.php
+++ b/tests/tests/DeserializerTest.php
@@ -15,6 +15,7 @@ use Aternos\Serializer\Test\Src\CustomSerializerInvalidTypeTestClass;
 use Aternos\Serializer\Test\Src\CustomSerializerTestClass;
 use Aternos\Serializer\Test\Src\DefaultValueTestClass;
 use Aternos\Serializer\Test\Src\IntersectionTestClass;
+use Aternos\Serializer\Test\Src\SecondTestClass;
 use Aternos\Serializer\Test\Src\SerializerTestClass;
 use Aternos\Serializer\Test\Src\TestClass;
 use Aternos\Serializer\Test\Src\UnionIntersectionTestClass;
@@ -496,16 +497,19 @@ class DeserializerTest extends TestCase
     public function testCustomDeserializer(): void
     {
         $deserializer = new JsonDeserializer(CustomSerializerTestClass::class);
-        $testClass = $deserializer->deserialize('{"testClass":"TzozNzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFRlc3RDbGFzcyI6OTp7czo2OiIAKgBhZ2UiO2k6MDtzOjE1OiIAKgBvcmlnaW5hbE5hbWUiO047czoxMToiACoAbnVsbGFibGUiO047czoxMjoiACoAYm9vbE9ySW50IjtiOjA7czoxNjoiACoAbm90QUpzb25GaWVsZCI7czo0OiJ0ZXN0IjtzOjE4OiIAKgBzZWNvbmRUZXN0Q2xhc3MiO047czo4OiIAKgBtaXhlZCI7TjtzOjg6IgAqAGZsb2F0IjtOO3M6ODoiACoAYXJyYXkiO047fQ=="}');
+        $testClass = $deserializer->deserialize('{"testClass":"Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ==","testArray":["Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ==","Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ=="]}');
         $this->assertInstanceOf(CustomSerializerTestClass::class, $testClass);
-        $this->assertInstanceOf(TestClass::class, $testClass->getTestClass());
+        $this->assertInstanceOf(SecondTestClass::class, $testClass->getTestClass());
+        $this->assertIsArray($testClass->getTestArray());
+        $this->assertInstanceOf(SecondTestClass::class, $testClass->getTestArray()[0]);
+        $this->assertInstanceOf(SecondTestClass::class, $testClass->getTestArray()[1]);
     }
 
     public function testCustomDeserializerReturnsInvalidType(): void
     {
         $deserializer = new JsonDeserializer(CustomSerializerInvalidTypeTestClass::class);
         $this->expectException(IncorrectTypeException::class);
-        $this->expectExceptionMessage("Expected '.testClass' to be 'Aternos\Serializer\Test\Src\TestClass' found: \Aternos\Serializer\Test\Src\SecondTestClass::__set_state(array(\n))");
-        $deserializer->deserialize('{"testClass":"Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ=="}');
+        $this->expectExceptionMessage("Expected '.testClass' to be 'Aternos\Serializer\Test\Src\TestClass' found: \Aternos\Serializer\Test\Src\BuiltInTypeTestClass::");
+        $deserializer->deserialize('{"testClass":"Tzo0ODoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXEJ1aWx0SW5UeXBlVGVzdENsYXNzIjo4OntzOjM6ImludCI7TjtzOjU6ImZsb2F0IjtOO3M6Njoic3RyaW5nIjtOO3M6NToiYXJyYXkiO047czo2OiJvYmplY3QiO047czo0OiJzZWxmIjtOO3M6NToiZmFsc2UiO047czo0OiJ0cnVlIjtOO30="}');
     }
 }

--- a/tests/tests/SerializeTest.php
+++ b/tests/tests/SerializeTest.php
@@ -21,9 +21,6 @@ class SerializeTest extends TestCase
 
     protected string $nonSerializedName = "this isn't serialized";
 
-    #[Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class))]
-    protected TestClass $testClass;
-
     public function testConstruct(): void
     {
         $property = new Serialize(
@@ -81,10 +78,16 @@ class SerializeTest extends TestCase
 
     public function testGetCustomSerializerAndDeserializer(): void
     {
-        $property = new ReflectionProperty($this, "testClass");
-        $attribute = Serialize::getAttribute($property);
+        $attribute = new Serialize(serializer: new Base64Serializer(), deserializer: new Base64Deserializer(TestClass::class));
         $this->assertNotNull($attribute);
         $this->assertInstanceOf(Base64Serializer::class, $attribute->getSerializer());
         $this->assertInstanceOf(Base64Deserializer::class, $attribute->getDeserializer());
+    }
+
+    public function testGetCustomItemSerializerAndDeserializer(): void
+    {
+        $attribute = new Serialize(itemSerializer: new Base64Serializer(), itemDeserializer: new Base64Deserializer(TestClass::class));
+        $this->assertInstanceOf(Base64Serializer::class, $attribute->getItemSerializer());
+        $this->assertInstanceOf(Base64Deserializer::class, $attribute->getItemDeserializer());
     }
 }

--- a/tests/tests/SerializerTest.php
+++ b/tests/tests/SerializerTest.php
@@ -128,7 +128,15 @@ class SerializerTest extends TestCase
     public function testCustomSerializer(): void
     {
         $testClass = new CustomSerializerTestClass();
-        $expected = '{"testClass":"TzozNzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFRlc3RDbGFzcyI6OTp7czo2OiIAKgBhZ2UiO2k6MDtzOjE1OiIAKgBvcmlnaW5hbE5hbWUiO047czoxMToiACoAbnVsbGFibGUiO047czoxMjoiACoAYm9vbE9ySW50IjtiOjA7czoxNjoiACoAbm90QUpzb25GaWVsZCI7czo0OiJ0ZXN0IjtzOjE4OiIAKgBzZWNvbmRUZXN0Q2xhc3MiO047czo4OiIAKgBtaXhlZCI7TjtzOjg6IgAqAGZsb2F0IjtOO3M6ODoiACoAYXJyYXkiO047fQ=="}';
+        $expected = '{"testClass":"Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ==","testArray":["Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ==","Tzo0MzoiQXRlcm5vc1xTZXJpYWxpemVyXFRlc3RcU3JjXFNlY29uZFRlc3RDbGFzcyI6MDp7fQ=="]}';
         $this->assertEquals($expected, json_encode($testClass));
+    }
+
+    public function testCustomItemSerializerThrowsIfItemIsNotAnObject(): void
+    {
+        $testClass = new CustomSerializerTestClass();
+        $testClass->setTestArray([1]);
+        $this->expectException(IncorrectTypeException::class);
+        json_encode($testClass);
     }
 }


### PR DESCRIPTION
Custom Serializers and Deserializers can also be specified for array items.

```php
#[Serialize(itemSerializer: new Base64Serializer(), itemDeserializer: new Base64Deserializer(TestClass::class))]
protected array $example = [];
```